### PR TITLE
Resolved erroneous system calls on Win10

### DIFF
--- a/R/RJuliaConnect.R
+++ b/R/RJuliaConnect.R
@@ -356,7 +356,6 @@ findJulia <- function(test = FALSE) {
 juliaCMD <- function(julia_bin, testFile, ...)
     if (.Platform$OS.type == "windows"){
       base::system2(command = julia_bin, args = paste0('"', testFile, '"'), ...)
-      paste0('"',julia_bin,'" ', testFile)
     } else {
       base::system(command = paste(julia_bin, testFile), ...)
     }

--- a/R/RJuliaConnect.R
+++ b/R/RJuliaConnect.R
@@ -93,7 +93,7 @@ JuliaInterface$methods(
                            Sys.setenv(RJuliaPort=port, RJuliaHost = host, RJuliaSource=juliaFolder)
                            if(identical(host, "localhost")) {
                                testJSON(julia_bin)
-                               base::system(juliaCMD(julia_bin, juliaStart), wait = FALSE)
+                               juliaCMD(julia_bin, juliaStart, wait = FALSE)
                            }
                        }
                        ## else, the Julia process should have been started and have called accept()
@@ -128,7 +128,7 @@ JuliaInterface$methods(
         value <- ServerTask("eval", expr, key, get)
         on.exit(serverWrapup <<- character())
         for(action in serverWrapup)
-            base::eval(base::parse(text = action))
+            base::eval(base::parse(text = action, encoding = "UTF-8"))
         XR::valueFromServer(value, key, get, .self)
     },
     ServerRemove = function(what)
@@ -353,14 +353,18 @@ findJulia <- function(test = FALSE) {
 
 ## command to run a julia file.
 ## Needs to allow for a blank in the Windows location ("Program Files")
-juliaCMD <- function(julia_bin, testFile)
-    if (.Platform$OS.type == "windows") paste0('"',julia_bin,'" ', testFile) else paste(julia_bin, testFile)
+juliaCMD <- function(julia_bin, testFile, ...)
+    if (.Platform$OS.type == "windows"){
+      base::system2(command = julia_bin, args = paste0('"', testFile, '"'), ...)
+      paste0('"',julia_bin,'" ', testFile)
+    } else {
+      base::system(command = paste(julia_bin, testFile), ...)
+    }
 
 testJSON <- function(julia_bin) {
-    testFile <- system.file("julia", "testJSON.jl", package = "XRJulia")
-    cmd <-  juliaCMD(julia_bin, testFile)
-    if(base::system(cmd)) # error exit from command
-        stop("Unable to continue:  failed to get JSON.  Try Pkg.add() from julia directly")
+    testFile <- system.file("julia", "testJSON.jl", package = .packageName)
+    if(juliaCMD(julia_bin, testFile)) # error exit from command
+      stop("Unable to continue:  failed to get JSON.  Try Pkg.add() from julia directly")
     TRUE
 }
     

--- a/R/RJuliaConnect.R
+++ b/R/RJuliaConnect.R
@@ -363,9 +363,16 @@ juliaCMD <- function(julia_bin, testFile, ...)
 
 testJSON <- function(julia_bin) {
     testFile <- system.file("julia", "testJSON.jl", package = .packageName)
-    if(juliaCMD(julia_bin, testFile)) # error exit from command
-      stop("Unable to continue:  failed to get JSON.  Try Pkg.add() from julia directly")
+    if(juliaCMD(julia_bin, testFile) > 0) # error exit from command
+      stop("Unable to continue:  failed to get JSON.jl - try Pkg.add() from julia directly")
     TRUE
+}
+
+testSockets <- function(julia_bin) {
+  testFile <- system.file("julia", "testSockets.jl", package = .packageName)
+  if(juliaCMD(julia_bin, testFile) > 0) # error exit from command
+    stop("Unable to continue:  failed to get Sockets.jl - try Pkg.add() from julia directly")
+  TRUE
 }
     
 

--- a/inst/julia/testSockets.jl
+++ b/inst/julia/testSockets.jl
@@ -1,0 +1,20 @@
+using Pkg
+
+function addSockets()
+    try
+        write(stderr, "Trying to add Julia package Sockets; expect some messages and some delay\n")
+        Pkg.add("Sockets")
+        0
+    catch err
+        write(stderr, "Unable to add package Sockets: ")
+        showerror(stderr, err)
+        1
+    end
+end
+
+try
+    import Sockets
+    exit(0)
+catch err
+    exit(addSockets())
+end

--- a/man/JuliaFunction-class.Rd
+++ b/man/JuliaFunction-class.Rd
@@ -44,8 +44,8 @@ if(findJulia(test = TRUE)) {
   set.seed(228)
   x <- matrix(rnorm(1000),20,5)
   xm <- juliaSend(x)
-  svdJ <- JuliaFunction("svdfact")
+  svdJ <- JuliaFunction("LinearAlgebra.svd")
   sxm <- svdJ(xm)
-  sxm
+  juliaGet(sxm)
 }
 }


### PR DESCRIPTION
The system() calls from JuliaXR resulted in error messages on my Win10 machine due to syntax issues in cmd with double quotes. Thus I revised to JuliaCMD function (besides some minor changes in the doc and adding a function to check for the Sockets package in Julia). 